### PR TITLE
enable container-fluid to fill wide screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="container">
+		<div class="container-fluid">
 			<div class="row">
 				<div class="col-md-6">
 					<div style="text-align: center;">Stromverbrauch</div>


### PR DESCRIPTION
Part of #14
Enable bootstrap 3.1 feature to fill wide screens.
Step one of the new layout for the big new Screen in RaumZeitLabor
