### PR TITLE
get rid of the 'flashing' of the RNV table

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -37,7 +37,6 @@ function updateGraph() {
 }
 
 function updateRnv(){
-	$('.rnvtable').remove();
 	$.ajax({
 		url: "rnv.php"
 	}).done(function(res){
@@ -59,6 +58,7 @@ function updateRnv(){
 		    row.append(abfahrten[i])
 		    tbl.append(row)
 		}
+		$('.rnvtable').remove();
 		$('#rnvcontent').append(tbl);
 
 	});


### PR DESCRIPTION
The RNV table was removed from the HTML before the ajax request for new data, which was then appended.
This took a little bit of time during which the Table is gone and then reappears. Resulting in a sort of "flashing".
I removed that by doing the ajax request first and after completion, removing the old table and inserting the new one in one go.
